### PR TITLE
chore: Update Cargo.toml use repository instead of homepage

### DIFF
--- a/styled/Cargo.toml
+++ b/styled/Cargo.toml
@@ -7,7 +7,7 @@ license = "APL-1.0"
 keywords = ["leptos", "scoped", "styles", "styling", "CSS"]
 categories = ["wasm", "web-programming"]
 readme = "README.md"
-homepage = "https://github.com/eboody/styled"
+repository = "https://github.com/eboody/styled"
 
 [dependencies]
 stylist = { version = "0.13.0" }

--- a/styled_macro/Cargo.toml
+++ b/styled_macro/Cargo.toml
@@ -7,7 +7,7 @@ license = "APL-1.0"
 keywords = ["leptos", "scoped", "styles", "styling", "CSS"]
 categories = ["wasm", "web-programming"]
 readme = "README.md"
-homepage = "https://github.com/eboody/styled"
+repository = "https://github.com/eboody/styled"
 
 [dependencies]
 proc-macro-error = "1.0.4"


### PR DESCRIPTION
According to the [manifest](https://doc.rust-lang.org/cargo/reference/manifest.html) it seems the `repository` field is preferable.  More explanation https://github.com/szabgab/rust-digger/issues/91